### PR TITLE
Use secure forward only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.1.0 - 2020-08-17
 - Update to infrastructure-bundle 1.5.0
+- Change the env var options from `IS_FORWARD_ONLY` to `IS_SECURE_FORWARD_ONLY`
 
 ## 1.0.1 - 2020-07-17
 - Fix an issue that made the integration generate incorrect cluster ARNs from

--- a/deploy/fargate_sidecar_example.json
+++ b/deploy/fargate_sidecar_example.json
@@ -23,7 +23,7 @@
             "value": ""
           },
           {
-            "name": "NRIA_IS_FORWARD_ONLY",
+            "name": "NRIA_IS_SECURE_FORWARD_ONLY",
             "value": "true"
           },
           {


### PR DESCRIPTION
With IS_FORWARD_ONLY the agent doesn't get an entity ID and the backend metadata decoration doesn't work. Secure forward mode fix this.