### PR TITLE
bump manifests

### DIFF
--- a/.github/workflows/release-manifests.yml
+++ b/.github/workflows/release-manifests.yml
@@ -1,0 +1,35 @@
+name: Release Manifest
+
+# This workflow should be run after the integration is released into a new infrastructure-bundle image version
+# or just want to bump the bundle version for the same integration version.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bundleVersion:
+        description: 'Version of Infra Bundle image without `v` prefix e.g. 2.6.4'
+        required: true
+      releaseVersion:
+        description: 'Version of nri-ecs without `v` prefix e.g. 1.3.1'
+        required: true
+
+jobs:
+  release-manifest:
+    needs: [ release-packages ]
+    name: Release manifest
+    runs-on: ubuntu-latest
+    env:
+      S3_BASE_FOLDER: s3://nr-downloads-main/infrastructure_agent
+    steps:
+      - uses: actions/checkout@v2
+      - if: ${{ github.event.release.prerelease }}
+        run: |
+          echo "S3_BASE_FOLDER=$S3_BASE_FOLDER/test" >> $GITHUB_ENV
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.COREINT_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.COREINT_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Upload configuration files to https://download.newrelic.com
+        run: |
+          make upload_manifests RELEASE_VERSION=${{ github.event.inputs.releaseVersion }} INFRA_BUNDLE_VERSION=${{ github.event.inputs.bundleVersion }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,5 +1,7 @@
-name: Release
+name: Release Packages
 
+# Post-release task1: bump the version of this integration in the infrastructure-bundle image.
+# Post-release task2: Bump bundle version on the make file and execute release-manifest workflow after new version of the infrastructure-bundle image is released.
 on:
   release:
     types: [prereleased, released]
@@ -21,23 +23,18 @@ jobs:
         run: |
           RELEASE_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-
       - name: Validate tag and release version
         run: |
           echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
           echo "$RELEASE_VERSION" | grep -E '^[0-9.]*[0-9]$'
-
       - if: ${{ github.event.release.prerelease }}
         run: |
           echo "S3_BASE_FOLDER=$S3_BASE_FOLDER/test" >> $GITHUB_ENV
-
       - uses: actions/checkout@v2
-
       - name: Build tarball
         run: |
           make test
           make package_for OS=$OS ARCH=$ARCH RELEASE_VERSION=$RELEASE_VERSION
-
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.COREINT_AWS_ACCESS_KEY_ID }}
@@ -46,35 +43,3 @@ jobs:
       - name: Upload tarball to https://download.newrelic.com
         run: |
           make release_tarball_package_for OS=$OS ARCH=$ARCH RELEASE_VERSION=$RELEASE_VERSION
-
-  release-manifest:
-    needs: [ release-packages ]
-    name: Release manifest
-    runs-on: ubuntu-latest
-    env:
-      S3_BASE_FOLDER: s3://nr-downloads-main/infrastructure_agent
-    steps:
-      - name: Generate version from tag
-        run: |
-          RELEASE_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-
-      - name: Validate tag and release version
-        run: |
-          echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
-          echo "$RELEASE_VERSION" | grep -E '^[0-9.]*[0-9]$'
-
-      - if: ${{ github.event.release.prerelease }}
-        run: |
-          echo "S3_BASE_FOLDER=$S3_BASE_FOLDER/test" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
-
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.COREINT_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.COREINT_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Upload configuration files to https://download.newrelic.com
-        run: |
-          make upload_manifests RELEASE_VERSION=$RELEASE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #### Please note that this dockerfile is not used to release the image,
 #### It is used merely to create a test image to run tests or to be uploaded manually for testing pourpuses
 ARG BASE_IMAGE=newrelic/infrastructure-bundle
-ARG BASE_IMAGE_TAG=2.4.1
+ARG BASE_IMAGE_TAG=2.6.4
 ARG GO_VERSION=1.13.8
 
 FROM golang:${GO_VERSION}-alpine AS build

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ NATIVEARCH	 := $(shell go version | awk -F '[ /]' '{print $$5}')
 INTEGRATION  := nri-ecs
 BINARY_NAME   = $(INTEGRATION)
 GO_PKGS      := $(shell go list ./... | grep -v "/vendor/")
-RELEASE_VERSION := 1.0.0
+RELEASE_VERSION ?= "dev" # Populated by release packages or manifest workflows.
 RELEASE_TAG :=
 RELEASE_STRING := ${RELEASE_VERSION}${RELEASE_TAG}
 
-INFRA_BUNDLE_VERSION := 2.4.1
+INFRA_BUNDLE_VERSION ?= "dev" # Populated by release manifest workflow.
 INFRA_BUNDLE_IMAGE := newrelic/infrastructure-bundle:$(INFRA_BUNDLE_VERSION)
 
 # compile & package targets


### PR DESCRIPTION
Release of this integration is separate in two parts due to the bundle image. One is the actual integration packages building and publishing and the other is the bump of the manifest once the infra bundle has a new release.

This PR separates that process into different workflows, And also bumps the infra bundle version to the 2.6.4.

The workflow that uploads the manifest will need to be run manually. Having this workflow running with the release doesn't make to many sense since is not posible to release the package and the bundle (with that package) at the same time. Also could be that there is no release of this integration involved and we just want it to update the bundle version.