### PR TITLE
chore: add runtimePlatform to fargate template

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,24 @@
+
+   
+{
+    "extends": [
+      "config:base"
+    ],
+    "enabledManagers": [
+      // Enable only the regex manager (for Dockerfile base image bumping). Go dependencies are managed by Dependabot.
+      "regex"
+    ],
+    "regexManagers": [
+      {
+        // Parse bundle image version from `BASE_IMAGE` ARG in Dockerfile.
+        "fileMatch": [
+          "^Dockerfile$"
+        ],
+        "datasourceTemplate": "docker",
+        "matchStrings": [
+          "BASE_IMAGE=(?<depName>.+):(?<currentValue>.+)"
+        ]
+      }
+    ]
+  }
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.4.1
+- Add runtime platform on Fargate task template
+
 ## 1.4.0
 - Now the integration is added to the `nri-ecs` image, which is based
   on the `infrastructure-bundle` image

--- a/deploy/fargate_sidecar_example.json
+++ b/deploy/fargate_sidecar_example.json
@@ -2,6 +2,9 @@
     "executionRoleArn": "<YOUR_TASK_EXECUTION_ROLE>",
     "networkMode": "awsvpc",
     "requiresCompatibilities": ["FARGATE"],
+    "runtimePlatform": {
+      "cpuArchitecture": "X86_64"
+    },
     "cpu": "256",
     "memory": "512",
     "containerDefinitions": [


### PR DESCRIPTION
Adding the configuration of the runtimePlatform in order to facilitate the installation on graviton by changing the cpuArch to `ARM64`