### PR TITLE
Nr 341876 make docker images pre release uniform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,51 +7,42 @@ on:
 jobs:
   release-pipeline:
     name: Release Pipeline
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
     with:
       original_repo_name: "newrelic/nri-ecs"
-      docker_platforms: "linux/amd64,linux/arm64,linux/arm"
       docker_image_name: "newrelic/nri-ecs"
-      s_three_path: "infrastructure_agent"
-      s_three_folder: "s3://nr-downloads-main/infrastructure_agent"
+
+      docker_platforms: "linux/amd64,linux/arm64,linux/arm"
+      
       go_version_file: "go.mod"
-      release_command: |
-        # Version validation as in original workflow
-        echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
+      bucket_url: "s3://nr-downloads-main/infrastructure_agent"
+      setup_aws_creds: true
+
+      release_command_sh: |
         
-        # Extract version from tag name
-        VERSION="${{ github.event.release.tag_name }}"
+        # Build the integration
+        make compile-multiarch RELEASE_VERSION=$VERSION
         
-        # Set S3 base folder with /test for pre-releases
+        # Append /test to S3 base folder for pre-releases
         if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-          export S3_BASE_FOLDER="s3://nr-downloads-main/infrastructure_agent/test"
-        else
-          export S3_BASE_FOLDER="s3://nr-downloads-main/infrastructure_agent"
+          export S3_BASE_FOLDER="${S3_BASE_FOLDER}/test"
         fi
         
-        # Build and upload steps with correct version handling
-        make compile-multiarch RELEASE_VERSION=$VERSION
-
+        # Pushes the image with / without "-pre" suffix based on if its a pre release 
         docker buildx build --push --platform=$DOCKER_PLATFORMS \
-          -t $DOCKER_IMAGE_NAME:$VERSION \
+          -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
           .
         
-        # Only push latest tag for full releases, not prereleases
+        # Push latest tag if its a release
         if [[ "${{ github.event.release.prerelease }}" == "false" ]]; then
           docker buildx build --push --platform=$DOCKER_PLATFORMS \
             -t $DOCKER_IMAGE_NAME:latest \
             .
         fi
         
-        # RELEASE_VERSION stays without suffix, only NRI_ECS_IMAGE_TAG gets the suffix
-        make upload_manifests RELEASE_VERSION=$VERSION NRI_ECS_IMAGE_TAG=$VERSION$TAG_SUFFIX
+        # Upload configuration files
+        make upload_manifests RELEASE_VERSION=$VERSION NRI_ECS_IMAGE_TAG=$DOCKER_IMAGE_TAG
 
-      use_build_push_action: false
-      use_custom_release: true
-      setup_aws_creds: true
-      run_nix_unit_tests: false
-      run_windows_unit_tests: false
-      run_integration_tests: false
     secrets:
       docker_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
       docker_password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         make compile-multiarch RELEASE_VERSION=$VERSION
 
         docker buildx build --push --platform=$DOCKER_PLATFORMS \
-          -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+          -t $DOCKER_IMAGE_NAME:$VERSION \
           .
         
         # Only push latest tag for full releases, not prereleases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release-pipeline:
     name: Release Pipeline
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-ecs"
       docker_image_name: "newrelic/nri-ecs"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,11 @@ on:
 jobs:
   release-pipeline:
     name: Release Pipeline
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
     with:
       original_repo_name: "newrelic/nri-ecs"
       docker_image_name: "newrelic/nri-ecs"
       
-      # bucket_url: using default
       setup_aws_creds: true
 
       release_command_sh: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         # Version validation as in original workflow
         echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
         
+        # Extract version from tag name
+        VERSION="${{ github.event.release.tag_name }}"
+        
         # Set S3 base folder with /test for pre-releases
         if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
           export S3_BASE_FOLDER="s3://nr-downloads-main/infrastructure_agent/test"
@@ -28,10 +31,22 @@ jobs:
         
         # Build and upload steps with correct version handling
         make compile-multiarch RELEASE_VERSION=$VERSION
+
+        docker buildx build --push --platform=$DOCKER_PLATFORMS \
+          -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+          .
+        
+        # Only push latest tag for full releases, not prereleases
+        if [[ "${{ github.event.release.prerelease }}" == "false" ]]; then
+          docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            -t $DOCKER_IMAGE_NAME:latest \
+            .
+        fi
         
         # RELEASE_VERSION stays without suffix, only NRI_ECS_IMAGE_TAG gets the suffix
         make upload_manifests RELEASE_VERSION=$VERSION NRI_ECS_IMAGE_TAG=$VERSION$TAG_SUFFIX
-      use_build_push_action: true
+
+      use_build_push_action: false
       use_custom_release: true
       setup_aws_creds: true
       run_nix_unit_tests: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,110 +4,40 @@ on:
   release:
     types: [prereleased, released]
 
-env:
-  ORIGINAL_REPO_NAME: "newrelic/nri-ecs"
-
 jobs:
-  release-image-manifest:
-    name: Release image and upload manifests
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_IMAGE_NAME: newrelic/nri-ecs
-      DOCKER_PLATFORMS: "linux/amd64,linux/arm64,linux/arm" # Must be consistent with the matrix make compile-multiarch.
-      S3_BASE_FOLDER: s3://nr-downloads-main/infrastructure_agent
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Generate version from tag
-        run: |
-          echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
-          NRI_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
-          echo "NRI_VERSION=$NRI_VERSION" >> $GITHUB_ENV
-          echo "DOCKER_IMAGE_TAG=$NRI_VERSION" >> $GITHUB_ENV
-
-      - name: Build integration
-        run: |
-          make compile-multiarch RELEASE_VERSION=$NRI_VERSION
-
-      - if: ${{ github.event.release.prerelease }}
-        run: |
-          echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}-pre" >> $GITHUB_ENV
-
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        run: |
-          docker buildx build --push --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
-            .
-
-      - name: Push :latest image
-        if: ${{ ! github.event.release.prerelease }}
-        run: |
-          docker buildx build --push --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME:latest \
-            .
-
-      - if: ${{ github.event.release.prerelease }}
-        run: |
-          echo "S3_BASE_FOLDER=$S3_BASE_FOLDER/test" >> $GITHUB_ENV
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.COREINT_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.COREINT_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Upload configuration files to https://download.newrelic.com
-        run: |
-          make upload_manifests RELEASE_VERSION=$NRI_VERSION NRI_ECS_IMAGE_TAG=$DOCKER_IMAGE_TAG
-
-      - if: ${{ github.event.release.prerelease }}
-        uses: actions/checkout@v4
-      - if: ${{ github.event.release.prerelease }}
-        name: Update title for successful pre-release
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name  }} --title "${{ github.event.release.tag_name  }}"
-
-
-  notify-failure:
-    if: ${{ always() && failure() }}
-    needs: [release-image-manifest]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify failure via Slack
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [image release failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."
-
-  update-title-on-failure:
-    if: ${{ always() && failure() }}
-    needs: [release-image-manifest]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - if: ${{ github.event.release.prerelease }}
-        name: Reflect failure in pre-release title
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name  }} --title "${{ github.event.release.tag_name }} (pre-release-failure)"
-      - if: ${{ ! github.event.release.prerelease }}
-        name: Reflect failure in release title
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name  }} --title "${{ github.event.release.tag_name }} (release-failure)"
+  release-pipeline:
+    name: Release Pipeline
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    with:
+      original_repo_name: "newrelic/nri-ecs"
+      docker_platforms: "linux/amd64,linux/arm64,linux/arm"
+      docker_image_name: "newrelic/nri-ecs"
+      s_three_path: "infrastructure_agent"
+      s_three_folder: "s3://nr-downloads-main/infrastructure_agent"
+      go_version_file: "go.mod"
+      release_command: |
+        # Version validation as in original workflow
+        echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
+        
+        # Set S3 base folder with /test for pre-releases
+        if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+          export S3_BASE_FOLDER="s3://nr-downloads-main/infrastructure_agent/test"
+        else
+          export S3_BASE_FOLDER="s3://nr-downloads-main/infrastructure_agent"
+        fi
+        
+        # Build and upload steps with correct version handling
+        make compile-multiarch RELEASE_VERSION=$VERSION
+        
+        # RELEASE_VERSION stays without suffix, only NRI_ECS_IMAGE_TAG gets the suffix
+        make upload_manifests RELEASE_VERSION=$VERSION NRI_ECS_IMAGE_TAG=$VERSION$TAG_SUFFIX
+      use_build_push_action: true
+      use_custom_release: true
+      setup_aws_creds: true
+      run_nix_unit_tests: false
+      run_windows_unit_tests: false
+      run_integration_tests: false
+    secrets:
+      docker_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
+      docker_password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
+      bot_token: ${{ secrets.COREINT_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,12 @@ on:
 jobs:
   release-pipeline:
     name: Release Pipeline
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-ecs"
       docker_image_name: "newrelic/nri-ecs"
-
-      docker_platforms: "linux/amd64,linux/arm64,linux/arm"
       
-      go_version_file: "go.mod"
-      bucket_url: "s3://nr-downloads-main/infrastructure_agent"
+      # bucket_url: using default
       setup_aws_creds: true
 
       release_command_sh: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,5 @@ jobs:
       docker_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
       docker_password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
       bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
+      aws_access_key_id: ${{ secrets.COREINT_AWS_ACCESS_KEY_ID }}
+      aws_access_key_secret: ${{ secrets.COREINT_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release-pipeline:
     name: Release Pipeline
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-ecs"
       docker_platforms: "linux/amd64,linux/arm64,linux/arm"


### PR DESCRIPTION
Tested prerelease / release successfully with the new reusable workflow.
Merge only after this: https://github.com/newrelic/coreint-automation/pull/103