### PR TITLE
fix: Fargate example should use Secrets Manager secret, not SSM

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -42,8 +42,15 @@ The script has a Fargate switch (`-f`) that can  be used to enable the Fargate m
 resources that are required to run Tasks with the sidecar contianer: IAM policies and roles, and the System's Manager
 parameter.
 
-In `sidecar_example.json` there is a task definition that contains an nginx container
-with the Agent & ECS integration as a sidecar.
+In `fargate_sidecar_example.json` there is a task definition that contains a
+sample container with the Agent & ECS integration as a sidecar.
+
+Note: this example's `NRIA_LICENSE_KEY` secret now points at a Secrets Manager
+ARN (`<NEW_RELIC_LICENSE_KEY_SECRET_ARN>`), to match the [CloudFormation
+deployment](cloudformation/README.md#fargate-launch-type). If you're using
+the `-f` installer script instead, its System Manager Parameter Store setup
+will no longer match this placeholder automatically — pass the parameter's
+ARN in manually, or use a Secrets Manager parameter for the license key.
 
 
 ### Compatibility

--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -29,6 +29,19 @@ in the `task.yaml` stack, then customers can do an update on the stack to
 register a new version of the `newrelic-infra` ECS task that uses the newly
 deployed `nri-ecs` container.
 
+## Fargate launch type
+
+`task.yaml` only registers a task compatible with the **EC2** and **EXTERNAL**
+launch types. For **Fargate**, register your own task definition based on
+[`../fargate_sidecar_example.json`](../fargate_sidecar_example.json) instead.
+
+That example's `NRIA_LICENSE_KEY` secret and `executionRoleArn` must be filled
+in with the outputs of the `NewRelicECSTaskExecutionRoleStack` nested stack
+(or the top-level `master.yaml` stack, which forwards them):
+
+* `<NEW_RELIC_LICENSE_KEY_SECRET_ARN>` → `LicenseKeySecretARN` output
+* `<YOUR_TASK_EXECUTION_ROLE>` → `ExecutionRoleARN` output
+
 ## Service creation stack
 
 This is the `service.yaml` stack, it creates the DAEMON service. You have to

--- a/deploy/fargate_sidecar_example.json
+++ b/deploy/fargate_sidecar_example.json
@@ -44,7 +44,7 @@
         ],
         "secrets": [
           {
-            "valueFrom": "<SYSTEM_MANAGER_LICENSE_PARAMETER_NAME>",
+            "valueFrom": "<NEW_RELIC_LICENSE_KEY_SECRET_ARN>",
             "name": "NRIA_LICENSE_KEY"
           }
         ],


### PR DESCRIPTION
Updates the AWS Fargate deployment examples.
**The Fix:** Changes the secret injection method from SSM Parameter Store to AWS Secrets Manager.
